### PR TITLE
Added several new cross-mod bees/customizations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ apply plugin: 'net.minecraftforge.gradle.forge'
 
 
 
-version = "1.10.2-1.2"
+version = "1.10.2-1.2.1"
 group= "lach_01298.morebees" 
 archivesBaseName = "morebees"
 

--- a/src/main/java/lach_01298/moreBees/Flowers.java
+++ b/src/main/java/lach_01298/moreBees/Flowers.java
@@ -6,11 +6,9 @@ import forestry.api.apiculture.FlowerManager;
 import forestry.apiculture.flowers.FlowerProvider;
 import forestry.core.genetics.alleles.IAlleleValue;
 
-public enum Flowers implements IAlleleValue<FlowerProvider> 
+public enum Flowers implements IAlleleValue<FlowerProvider>
 {
 	ORE(Register.FlowerOre, true),
-	DIAMOND(Register.FlowerDiamond,true),
-	EMERALD(Register.FlowerEmerald,true),
 	REDSTONE(Register.FlowerRedstone,true),
 	URANIUM(Register.FlowerUranium,true),
 	WATER(Register.FlowerWater),
@@ -20,12 +18,12 @@ public enum Flowers implements IAlleleValue<FlowerProvider>
 	private final FlowerProvider value;
 	private final boolean dominant;
 
-	Flowers(String flowerType) 
+	Flowers(String flowerType)
 	{
 		this(flowerType, false);
 	}
 
-	Flowers(String flowerType, boolean dominant) 
+	Flowers(String flowerType, boolean dominant)
 	{
 		String lowercaseName = toString().toLowerCase(Locale.ENGLISH);
 		this.value = new FlowerProvider(flowerType, "for.flowers." + lowercaseName);
@@ -34,16 +32,16 @@ public enum Flowers implements IAlleleValue<FlowerProvider>
 
 
 	@Override
-	public FlowerProvider getValue() 
+	public FlowerProvider getValue()
 	{
-		
+
 		return value;
 	}
 
 	@Override
-	public boolean isDominant() 
+	public boolean isDominant()
 	{
-		
+
 		return dominant;
 	}
 }

--- a/src/main/java/lach_01298/moreBees/Genetics/BeeSpecies.java
+++ b/src/main/java/lach_01298/moreBees/Genetics/BeeSpecies.java
@@ -46,7 +46,8 @@ public enum BeeSpecies implements IBeeDefinition
 		@Override
 		protected void setSpeciesProperties(IAlleleBeeSpeciesBuilder beeSpecies)
 		{
-			beeSpecies.addProduct(new ItemStack(MoreBeesItems.CombRock), 0.30f).setTemperature(EnumTemperature.NORMAL).setHumidity(EnumHumidity.NORMAL);
+			beeSpecies.addProduct(new ItemStack(MoreBeesItems.CombRock), 0.30f)
+			          .setTemperature(EnumTemperature.NORMAL).setHumidity(EnumHumidity.NORMAL);
 		}
 
 		@Override
@@ -72,7 +73,8 @@ public enum BeeSpecies implements IBeeDefinition
 		@Override
 		protected void setSpeciesProperties(IAlleleBeeSpeciesBuilder beeSpecies)
 		{
-			beeSpecies.addProduct(new ItemStack(MoreBeesItems.CombRock), 0.35f).setTemperature(EnumTemperature.NORMAL).setHumidity(EnumHumidity.NORMAL);
+			beeSpecies.addProduct(new ItemStack(MoreBeesItems.CombRock), 0.35f)
+			          .setTemperature(EnumTemperature.NORMAL).setHumidity(EnumHumidity.NORMAL);
 		}
 
 		@Override
@@ -99,7 +101,9 @@ public enum BeeSpecies implements IBeeDefinition
 		@Override
 		protected void setSpeciesProperties(IAlleleBeeSpeciesBuilder beeSpecies)
 		{
-			beeSpecies.addProduct(new ItemStack(MoreBeesItems.CombRock), 0.40f).addProduct(new ItemStack(Blocks.OBSIDIAN), 0.1f).setTemperature(EnumTemperature.WARM).setHumidity(EnumHumidity.NORMAL);
+			beeSpecies.addProduct(new ItemStack(MoreBeesItems.CombRock), 0.40f)
+			          .addProduct(new ItemStack(Blocks.OBSIDIAN), 0.1f)
+			          .setTemperature(EnumTemperature.WARM).setHumidity(EnumHumidity.NORMAL);
 
 		}
 
@@ -128,7 +132,9 @@ public enum BeeSpecies implements IBeeDefinition
 		@Override
 		protected void setSpeciesProperties(IAlleleBeeSpeciesBuilder beeSpecies)
 		{
-			beeSpecies.addProduct(new ItemStack(MoreBeesItems.CombRock), 0.30f).addProduct(new ItemStack(Items.DYE, 1, 4), 0.1f).setTemperature(EnumTemperature.WARM).setHumidity(EnumHumidity.NORMAL);
+			beeSpecies.addProduct(new ItemStack(MoreBeesItems.CombRock), 0.30f)
+			          .addProduct(new ItemStack(Items.DYE, 1, 4), 0.1f)
+			          .setTemperature(EnumTemperature.WARM).setHumidity(EnumHumidity.NORMAL);
 
 		}
 
@@ -157,7 +163,8 @@ public enum BeeSpecies implements IBeeDefinition
 		@Override
 		protected void setSpeciesProperties(IAlleleBeeSpeciesBuilder beeSpecies)
 		{
-			beeSpecies.addProduct(new ItemStack(MoreBeesItems.CombDirt), 0.40f).setTemperature(EnumTemperature.NORMAL).setHumidity(EnumHumidity.NORMAL);
+			beeSpecies.addProduct(new ItemStack(MoreBeesItems.CombDirt), 0.40f)
+			          .setTemperature(EnumTemperature.NORMAL).setHumidity(EnumHumidity.NORMAL);
 		}
 
 		@Override
@@ -188,7 +195,8 @@ public enum BeeSpecies implements IBeeDefinition
 		protected void setSpeciesProperties(IAlleleBeeSpeciesBuilder beeSpecies)
 		{
 
-			beeSpecies.addProduct(new ItemStack(MoreBeesItems.CombDirt), 0.30f).addProduct(new ItemStack(Items.CLAY_BALL), 1.0f).addProduct(new ItemStack(Items.CLAY_BALL), 0.5f).addProduct(new ItemStack(Items.CLAY_BALL), 0.5f).addProduct(new ItemStack(Items.CLAY_BALL), 0.5f).setTemperature(EnumTemperature.NORMAL).setHumidity(EnumHumidity.DAMP);
+			beeSpecies.addProduct(new ItemStack(MoreBeesItems.CombDirt), 0.30f)
+			          .addProduct(new ItemStack(Items.CLAY_BALL), 1.0f).addProduct(new ItemStack(Items.CLAY_BALL), 0.5f).addProduct(new ItemStack(Items.CLAY_BALL), 0.5f).addProduct(new ItemStack(Items.CLAY_BALL), 0.5f).setTemperature(EnumTemperature.NORMAL).setHumidity(EnumHumidity.DAMP);
 		}
 
 		@Override
@@ -213,7 +221,12 @@ public enum BeeSpecies implements IBeeDefinition
 		@Override
 		protected void setSpeciesProperties(IAlleleBeeSpeciesBuilder beeSpecies)
 		{
-			beeSpecies.addProduct(new ItemStack(MoreBeesItems.CombDirt), 0.30f).addProduct(new ItemStack(Blocks.SAND), 0.40f).addProduct(new ItemStack(Blocks.SAND, 1, 1), 0.70f).addProduct(new ItemStack(Blocks.SAND, 2, 1), 0.30f).addProduct(new ItemStack(Blocks.SAND, 1, 1), 0.20f).setTemperature(EnumTemperature.HOT).setHumidity(EnumHumidity.ARID);
+			beeSpecies.addProduct(new ItemStack(MoreBeesItems.CombDirt), 0.30f)
+			          .addProduct(new ItemStack(Blocks.SAND), 0.40f)
+			          .addProduct(new ItemStack(Blocks.SAND, 1, 1), 0.70f)
+			          .addProduct(new ItemStack(Blocks.SAND, 2, 1), 0.30f)
+			          .addProduct(new ItemStack(Blocks.SAND, 1, 1), 0.20f)
+			          .setTemperature(EnumTemperature.HOT).setHumidity(EnumHumidity.ARID);
 		}
 
 		@Override
@@ -237,12 +250,45 @@ public enum BeeSpecies implements IBeeDefinition
 		}
 	},
 	// Crystal branch
+	QUARTZ(BeeBranches.CRYSTAL, "Quartz", false, new Color(0xf4f6f6), new Color(0xffdc16))
+	{
+		@Override
+		protected void setSpeciesProperties(IAlleleBeeSpeciesBuilder beeSpecies)
+		{
+			beeSpecies.addProduct(new ItemStack(MoreBeesItems.CombRock), 0.30f)
+			          .addProduct(new ItemStack(Items.QUARTZ), 0.30f)
+			          .setTemperature(EnumTemperature.WARM).setHumidity(EnumHumidity.NORMAL);
+
+		}
+
+		@Override
+		protected void setAlleles(IAllele[] template)
+		{
+			AlleleHelper.instance.set(template, EnumBeeChromosome.FERTILITY, EnumAllele.Fertility.LOW);
+			AlleleHelper.instance.set(template, EnumBeeChromosome.CAVE_DWELLING, true);
+			AlleleHelper.instance.set(template, EnumBeeChromosome.HUMIDITY_TOLERANCE, EnumAllele.Tolerance.BOTH_2);
+			AlleleHelper.instance.set(template, EnumBeeChromosome.TEMPERATURE_TOLERANCE, EnumAllele.Tolerance.UP_1);
+			AlleleHelper.instance.set(template, EnumBeeChromosome.FLOWER_PROVIDER, Register.FlowerTypeRedstone);
+			AlleleHelper.instance.set(template, EnumBeeChromosome.SPEED, EnumAllele.Speed.SLOW);
+		}
+
+		@Override
+		protected void registerMutations()
+		{
+
+			BeeManager.beeMutationFactory.createMutation(LapisBee, SinisterBee, getTemplate(), MathUtil.maxInt((int)(10*Config.mutationMultipler),100));
+
+		}
+	},
 	REDSTONE(BeeBranches.CRYSTAL, "Redstone", false, new Color(0xaa0404), new Color(0xffdc16))
 	{
 		@Override
 		protected void setSpeciesProperties(IAlleleBeeSpeciesBuilder beeSpecies)
 		{
-			beeSpecies.addProduct(new ItemStack(MoreBeesItems.CombRock), 0.30f).addProduct(new ItemStack(Items.REDSTONE), 0.30f).addProduct(new ItemStack(Items.REDSTONE), 0.20f).setTemperature(EnumTemperature.WARM).setHumidity(EnumHumidity.NORMAL);
+			beeSpecies.addProduct(new ItemStack(MoreBeesItems.CombRock), 0.30f)
+			          .addProduct(new ItemStack(Items.REDSTONE), 0.30f)
+			          .addProduct(new ItemStack(Items.REDSTONE), 0.20f)
+			          .setTemperature(EnumTemperature.WARM).setHumidity(EnumHumidity.NORMAL);
 
 		}
 
@@ -270,7 +316,10 @@ public enum BeeSpecies implements IBeeDefinition
 		@Override
 		protected void setSpeciesProperties(IAlleleBeeSpeciesBuilder beeSpecies)
 		{
-			beeSpecies.addProduct(new ItemStack(MoreBeesItems.CombRock), 0.30f).addProduct(new ItemStack(MoreBeesItems.EmeraldFrag), 0.15f).setTemperature(EnumTemperature.WARM).setHumidity(EnumHumidity.NORMAL);
+			beeSpecies.addProduct(new ItemStack(MoreBeesItems.CombRock), 0.30f)
+			          .addSpecialty(new ItemStack(MoreBeesItems.EmeraldFrag), 0.15f)
+			          .setJubilanceProvider(BeeManager.jubilanceFactory.getRequiresResource(Blocks.EMERALD_BLOCK.getDefaultState()))
+			          .setTemperature(EnumTemperature.WARM).setHumidity(EnumHumidity.NORMAL);
 
 		}
 
@@ -281,7 +330,6 @@ public enum BeeSpecies implements IBeeDefinition
 			AlleleHelper.instance.set(template, EnumBeeChromosome.CAVE_DWELLING, true);
 			AlleleHelper.instance.set(template, EnumBeeChromosome.HUMIDITY_TOLERANCE, EnumAllele.Tolerance.BOTH_2);
 			AlleleHelper.instance.set(template, EnumBeeChromosome.TEMPERATURE_TOLERANCE, EnumAllele.Tolerance.UP_1);
-			AlleleHelper.instance.set(template, EnumBeeChromosome.FLOWER_PROVIDER, Register.FlowerTypeEmerald);
 			AlleleHelper.instance.set(template, EnumBeeChromosome.SPEED, EnumAllele.Speed.SLOWER);
 		}
 
@@ -298,7 +346,11 @@ public enum BeeSpecies implements IBeeDefinition
 		@Override
 		protected void setSpeciesProperties(IAlleleBeeSpeciesBuilder beeSpecies)
 		{
-			beeSpecies.addProduct(new ItemStack(MoreBeesItems.CombRock), 0.30f).addProduct(new ItemStack(MoreBeesItems.DiamondFrag), 0.15f).setHasEffect().setTemperature(EnumTemperature.WARM).setHumidity(EnumHumidity.NORMAL);
+			beeSpecies.addProduct(new ItemStack(MoreBeesItems.CombRock), 0.30f)
+			          .addSpecialty(new ItemStack(MoreBeesItems.DiamondFrag), 0.15f)
+			          .setJubilanceProvider(BeeManager.jubilanceFactory.getRequiresResource(Blocks.DIAMOND_BLOCK.getDefaultState()))
+			          .setHasEffect()
+			          .setTemperature(EnumTemperature.WARM).setHumidity(EnumHumidity.NORMAL);
 
 		}
 
@@ -309,7 +361,6 @@ public enum BeeSpecies implements IBeeDefinition
 			AlleleHelper.instance.set(template, EnumBeeChromosome.CAVE_DWELLING, true);
 			AlleleHelper.instance.set(template, EnumBeeChromosome.HUMIDITY_TOLERANCE, EnumAllele.Tolerance.UP_1);
 			AlleleHelper.instance.set(template, EnumBeeChromosome.TEMPERATURE_TOLERANCE, EnumAllele.Tolerance.UP_1);
-			AlleleHelper.instance.set(template, EnumBeeChromosome.FLOWER_PROVIDER, Register.FlowerTypeDiamond);
 			AlleleHelper.instance.set(template, EnumBeeChromosome.SPEED, EnumAllele.Speed.SLOWEST);
 		}
 
@@ -328,7 +379,9 @@ public enum BeeSpecies implements IBeeDefinition
 		{
 			if(LoadMods.enableRuby)
 			{
-				beeSpecies.addProduct(new ItemStack(MoreBeesItems.CombRock), 0.30f).addProduct(OreDicPreferences.get("gemRuby", 1), 0.15f).setTemperature(EnumTemperature.WARM).setHumidity(EnumHumidity.NORMAL);
+				beeSpecies.addProduct(new ItemStack(MoreBeesItems.CombRock), 0.30f)
+				          .addProduct(OreDicPreferences.get("gemRuby", 1), 0.15f)
+				          .setTemperature(EnumTemperature.WARM).setHumidity(EnumHumidity.NORMAL);
 			}
 		}
 
@@ -357,7 +410,9 @@ public enum BeeSpecies implements IBeeDefinition
 		{
 			if(LoadMods.enableSapphire)
 			{
-				beeSpecies.addProduct(new ItemStack(MoreBeesItems.CombRock), 0.30f).addProduct(OreDicPreferences.get("gemSapphire", 1), 0.15f).setTemperature(EnumTemperature.WARM).setHumidity(EnumHumidity.NORMAL);
+				beeSpecies.addProduct(new ItemStack(MoreBeesItems.CombRock), 0.30f)
+				          .addProduct(OreDicPreferences.get("gemSapphire", 1), 0.15f)
+				          .setTemperature(EnumTemperature.WARM).setHumidity(EnumHumidity.NORMAL);
 			}
 		}
 
@@ -386,7 +441,9 @@ public enum BeeSpecies implements IBeeDefinition
 		{
 			if(LoadMods.enableSulfur)
 			{
-				 beeSpecies.addProduct(PluginApiculture.items.beeComb.get(EnumHoneyComb.SIMMERING, 1), 0.3f).addProduct(OreDicPreferences.get("dustSulfur", 1), 0.15f).setTemperature(EnumTemperature.WARM).setHumidity(EnumHumidity.NORMAL);			
+				 beeSpecies.addProduct(PluginApiculture.items.beeComb.get(EnumHoneyComb.SIMMERING, 1), 0.3f)
+				           .addProduct(OreDicPreferences.get("dustSulfur", 1), 0.15f)
+				           .setTemperature(EnumTemperature.WARM).setHumidity(EnumHumidity.NORMAL);
 			}
 		}
 
@@ -413,8 +470,10 @@ public enum BeeSpecies implements IBeeDefinition
 		@Override
 		protected void setSpeciesProperties(IAlleleBeeSpeciesBuilder beeSpecies)
 		{
-			
-		        beeSpecies.addProduct(new ItemStack(MoreBeesItems.CombRock),0.3f).addProduct(new ItemStack(PluginCore.items.apatite),0.1f).setTemperature(EnumTemperature.WARM).setHumidity(EnumHumidity.NORMAL);
+
+		        beeSpecies.addProduct(new ItemStack(MoreBeesItems.CombRock),0.3f)
+		                  .addProduct(new ItemStack(PluginCore.items.apatite),0.1f)
+		                  .setTemperature(EnumTemperature.WARM).setHumidity(EnumHumidity.NORMAL);
 		}
 
 		@Override
@@ -437,12 +496,14 @@ public enum BeeSpecies implements IBeeDefinition
 	},
 
 	// Metal Branch
-	Metallic(BeeBranches.METAL, "Metallic", true, new Color(0x999999), new Color(0x999999))
+	METALLIC(BeeBranches.METAL, "Metallic", true, new Color(0x999999), new Color(0x999999))
 	{
 		@Override
 		protected void setSpeciesProperties(IAlleleBeeSpeciesBuilder beeSpecies)
 		{
-			beeSpecies.addProduct(new ItemStack(MoreBeesItems.CombRock), 0.30f).addProduct(OreDicPreferences.get("dustIron", 1), 0.05f).setTemperature(EnumTemperature.WARM).setHumidity(EnumHumidity.NORMAL);
+			beeSpecies.addProduct(new ItemStack(MoreBeesItems.CombRock), 0.30f)
+			          .addProduct(OreDicPreferences.get("dustIron", 1), 0.05f)
+			          .setTemperature(EnumTemperature.WARM).setHumidity(EnumHumidity.NORMAL);
 
 		}
 
@@ -471,7 +532,9 @@ public enum BeeSpecies implements IBeeDefinition
 		@Override
 		protected void setSpeciesProperties(IAlleleBeeSpeciesBuilder beeSpecies)
 		{
-			beeSpecies.addProduct(new ItemStack(MoreBeesItems.CombRock), 0.30f).addProduct(OreDicPreferences.get("dustIron", 1), 0.15f).setTemperature(EnumTemperature.WARM).setHumidity(EnumHumidity.NORMAL);
+			beeSpecies.addProduct(new ItemStack(MoreBeesItems.CombRock), 0.30f)
+			          .addProduct(OreDicPreferences.get("dustIron", 1), 0.15f)
+			          .setTemperature(EnumTemperature.WARM).setHumidity(EnumHumidity.NORMAL);
 
 		}
 
@@ -498,7 +561,9 @@ public enum BeeSpecies implements IBeeDefinition
 		@Override
 		protected void setSpeciesProperties(IAlleleBeeSpeciesBuilder beeSpecies)
 		{
-			beeSpecies.addProduct(new ItemStack(MoreBeesItems.CombRock), 0.30f).addProduct(OreDicPreferences.get("dustCopper", 1), 0.15f).setTemperature(EnumTemperature.WARM).setHumidity(EnumHumidity.NORMAL);
+			beeSpecies.addProduct(new ItemStack(MoreBeesItems.CombRock), 0.30f)
+			          .addProduct(OreDicPreferences.get("dustCopper", 1), 0.15f)
+			          .setTemperature(EnumTemperature.WARM).setHumidity(EnumHumidity.NORMAL);
 		}
 
 		@Override
@@ -524,7 +589,9 @@ public enum BeeSpecies implements IBeeDefinition
 		@Override
 		protected void setSpeciesProperties(IAlleleBeeSpeciesBuilder beeSpecies)
 		{
-			beeSpecies.addProduct(new ItemStack(MoreBeesItems.CombRock), 0.30f).addProduct(OreDicPreferences.get("dustTin", 1), 0.15f).setTemperature(EnumTemperature.WARM).setHumidity(EnumHumidity.NORMAL);
+			beeSpecies.addProduct(new ItemStack(MoreBeesItems.CombRock), 0.30f)
+			          .addProduct(OreDicPreferences.get("dustTin", 1), 0.15f)
+			          .setTemperature(EnumTemperature.WARM).setHumidity(EnumHumidity.NORMAL);
 		}
 
 		@Override
@@ -552,7 +619,9 @@ public enum BeeSpecies implements IBeeDefinition
 		{
 			if(LoadMods.enableAluminium)
 			{
-				beeSpecies.addProduct(new ItemStack(MoreBeesItems.CombRock), 0.30f).addProduct(OreDicPreferences.get("dustAluminum", 1), 0.15f).setTemperature(EnumTemperature.WARM).setHumidity(EnumHumidity.NORMAL);
+				beeSpecies.addProduct(new ItemStack(MoreBeesItems.CombRock), 0.30f)
+				          .addProduct(OreDicPreferences.get("dustAluminum", 1), 0.15f)
+				          .setTemperature(EnumTemperature.WARM).setHumidity(EnumHumidity.NORMAL);
 			}
 		}
 
@@ -579,7 +648,9 @@ public enum BeeSpecies implements IBeeDefinition
 		@Override
 		protected void setSpeciesProperties(IAlleleBeeSpeciesBuilder beeSpecies)
 		{
-			beeSpecies.addProduct(new ItemStack(MoreBeesItems.CombRock), 0.30f).addProduct(OreDicPreferences.get("dustGold", 1), 0.15f).setTemperature(EnumTemperature.WARM).setHumidity(EnumHumidity.NORMAL);
+			beeSpecies.addProduct(new ItemStack(MoreBeesItems.CombRock), 0.30f)
+			          .addProduct(OreDicPreferences.get("dustGold", 1), 0.15f)
+			          .setTemperature(EnumTemperature.WARM).setHumidity(EnumHumidity.NORMAL);
 
 		}
 
@@ -608,7 +679,9 @@ public enum BeeSpecies implements IBeeDefinition
 		{
 			if(LoadMods.enableSilver)
 			{
-				beeSpecies.addProduct(new ItemStack(MoreBeesItems.CombRock), 0.30f).addProduct(OreDicPreferences.get("dustSilver", 1), 0.15f).setTemperature(EnumTemperature.WARM).setHumidity(EnumHumidity.NORMAL);
+				beeSpecies.addProduct(new ItemStack(MoreBeesItems.CombRock), 0.30f)
+				          .addProduct(OreDicPreferences.get("dustSilver", 1), 0.15f)
+				          .setTemperature(EnumTemperature.WARM).setHumidity(EnumHumidity.NORMAL);
 			}
 		}
 
@@ -637,7 +710,9 @@ public enum BeeSpecies implements IBeeDefinition
 		{
 			if(LoadMods.enableLead)
 			{
-				beeSpecies.addProduct(new ItemStack(MoreBeesItems.CombRock), 0.30f).addProduct(OreDicPreferences.get("dustLead", 1), 0.15f).setTemperature(EnumTemperature.WARM).setHumidity(EnumHumidity.NORMAL);
+				beeSpecies.addProduct(new ItemStack(MoreBeesItems.CombRock), 0.30f)
+				          .addProduct(OreDicPreferences.get("dustLead", 1), 0.15f)
+				          .setTemperature(EnumTemperature.WARM).setHumidity(EnumHumidity.NORMAL);
 			}
 		}
 
@@ -666,7 +741,9 @@ public enum BeeSpecies implements IBeeDefinition
 		{
 			if(LoadMods.enableTinkers)
 			{
-				beeSpecies.addProduct(new ItemStack(MoreBeesItems.CombRock), 0.30f).addProduct(OreDicPreferences.get("nuggetCobalt", 1), 0.15f).setTemperature(EnumTemperature.HELLISH).setHumidity(EnumHumidity.ARID);
+				beeSpecies.addProduct(new ItemStack(MoreBeesItems.CombRock), 0.30f)
+				          .addProduct(OreDicPreferences.get("nuggetCobalt", 1), 0.15f)
+				          .setTemperature(EnumTemperature.HELLISH).setHumidity(EnumHumidity.ARID);
 			}
 		}
 
@@ -695,7 +772,9 @@ public enum BeeSpecies implements IBeeDefinition
 		{
 			if(LoadMods.enableTinkers)
 			{
-				beeSpecies.addProduct(new ItemStack(MoreBeesItems.CombRock), 0.30f).addProduct(OreDicPreferences.get("nuggetArdite", 1), 0.15f).setTemperature(EnumTemperature.HELLISH).setHumidity(EnumHumidity.ARID);
+				beeSpecies.addProduct(new ItemStack(MoreBeesItems.CombRock), 0.30f)
+				          .addProduct(OreDicPreferences.get("nuggetArdite", 1), 0.15f)
+				          .setTemperature(EnumTemperature.HELLISH).setHumidity(EnumHumidity.ARID);
 			}
 		}
 
@@ -717,6 +796,37 @@ public enum BeeSpecies implements IBeeDefinition
 
 		}
 	},
+	OSMIUM(BeeBranches.METAL, "Osmium", false, new Color(0x33caff), new Color(0x999999))
+	{
+		@Override
+		protected void setSpeciesProperties(IAlleleBeeSpeciesBuilder beeSpecies)
+		{
+			if(LoadMods.enableOsmium)
+			{
+				beeSpecies.addProduct(new ItemStack(MoreBeesItems.CombRock), 0.30f)
+				          .addProduct(OreDicPreferences.get("dustOsmium", 1), 0.15f)
+				          .setTemperature(EnumTemperature.WARM).setHumidity(EnumHumidity.NORMAL);
+			}
+		}
+
+		@Override
+		protected void setAlleles(IAllele[] template)
+		{
+			AlleleHelper.instance.set(template, EnumBeeChromosome.FERTILITY, EnumAllele.Fertility.NORMAL);
+			AlleleHelper.instance.set(template, EnumBeeChromosome.CAVE_DWELLING, true);
+			AlleleHelper.instance.set(template, EnumBeeChromosome.TEMPERATURE_TOLERANCE, EnumAllele.Tolerance.UP_1);
+			AlleleHelper.instance.set(template, EnumBeeChromosome.HUMIDITY_TOLERANCE, EnumAllele.Tolerance.BOTH_2);
+			AlleleHelper.instance.set(template, EnumBeeChromosome.SPEED, EnumAllele.Speed.NORMAL);
+		}
+
+		@Override
+		protected void registerMutations()
+		{
+
+			BeeManager.beeMutationFactory.createMutation(CopperBee, IndustriousBee, getTemplate(), MathUtil.maxInt((int)(10*Config.mutationMultipler),100));
+
+		}
+	},
 	// RadioActive branch
 	RADIOACTIVE(BeeBranches.RADIOACTIVE, "Radioactive", true, new Color(0x3e720c), new Color(0x999999))
 	{
@@ -725,14 +835,24 @@ public enum BeeSpecies implements IBeeDefinition
 		{
 			if(LoadMods.enableUranium && !LoadMods.enableIC2Classic)
 			{
-				beeSpecies.addProduct(new ItemStack(MoreBeesItems.CombRock), 0.30f).addProduct(OreDicPreferences.get("oreUranium", 1), 0.1f).setTemperature(EnumTemperature.HOT).setHumidity(EnumHumidity.NORMAL);
+				beeSpecies.addProduct(new ItemStack(MoreBeesItems.CombRock), 0.30f)
+				          .addProduct(OreDicPreferences.get("oreUranium", 1), 0.05f)
+				          .setTemperature(EnumTemperature.HOT).setHumidity(EnumHumidity.NORMAL);
 			}
 			else if(LoadMods.enableIC2Classic)
 			{
-				beeSpecies.addProduct(new ItemStack(MoreBeesItems.CombRock), 0.30f).addProduct(OreDicPreferences.get("dropUranium", 1), 0.1f).setTemperature(EnumTemperature.HOT).setHumidity(EnumHumidity.NORMAL);
+				beeSpecies.addProduct(new ItemStack(MoreBeesItems.CombRock), 0.30f)
+				          .addProduct(OreDicPreferences.get("dropUranium", 1), 0.05f)
+				          .setTemperature(EnumTemperature.HOT).setHumidity(EnumHumidity.NORMAL);
 
 			}
-			
+			else if (LoadMods.enableResonating)
+			{
+				beeSpecies.addProduct(new ItemStack(MoreBeesItems.CombRock), 0.30f)
+				          .addProduct(OreDicPreferences.get("oreResonating", 1), 0.05f)
+				          .setTemperature(EnumTemperature.HOT).setHumidity(EnumHumidity.NORMAL);
+			}
+
 		}
 
 		@Override
@@ -763,12 +883,22 @@ public enum BeeSpecies implements IBeeDefinition
 		{
 			if(LoadMods.enableIC2 && !LoadMods.enableIC2Classic)
 			{
-				beeSpecies.addProduct(new ItemStack(MoreBeesItems.CombRock), 0.30f).addProduct(OreDicPreferences.get("crushedUranium", 1), 0.15f).setHasEffect().setTemperature(EnumTemperature.HELLISH).setHumidity(EnumHumidity.ARID);
+				beeSpecies.addProduct(new ItemStack(MoreBeesItems.CombRock), 0.30f)
+				          .addProduct(OreDicPreferences.get("crushedUranium", 1), 0.15f)
+				          .setHasEffect()
+				          .setTemperature(EnumTemperature.HELLISH).setHumidity(EnumHumidity.ARID);
 			}
 			else if(LoadMods.enableIC2Classic)
 			{
-				beeSpecies.addProduct(new ItemStack(MoreBeesItems.CombRock), 0.30f).addProduct(OreDicPreferences.get("dropUranium", 1), 0.15f).setHasEffect().setTemperature(EnumTemperature.HELLISH).setHumidity(EnumHumidity.ARID);
+				beeSpecies.addProduct(new ItemStack(MoreBeesItems.CombRock), 0.30f)
+				          .addProduct(OreDicPreferences.get("dropUranium", 1), 0.15f)
+				          .setHasEffect()
+				          .setTemperature(EnumTemperature.HELLISH).setHumidity(EnumHumidity.ARID);
 
+			}
+			else if (LoadMods.enableResonating)
+			{
+				beeSpecies.addProduct(new ItemStack(MoreBeesItems.CombRock), 0.30f).addProduct(OreDicPreferences.get("oreResonating", 1), 0.15f).setTemperature(EnumTemperature.HOT).setHumidity(EnumHumidity.NORMAL);
 			}
 		}
 
@@ -791,6 +921,33 @@ public enum BeeSpecies implements IBeeDefinition
 
 		}
 	},
+	DRACONIC(BeeBranchDefinition.END, "Draconic", true, new Color(0xd088e4), new Color(0x830d0d))
+	{
+		@Override
+		protected void setSpeciesProperties(IAlleleBeeSpeciesBuilder beeSpecies)
+		{
+			if (LoadMods.enableDraconium)
+			{
+				beeSpecies.addProduct(PluginApiculture.items.beeComb.get(EnumHoneyComb.MYSTERIOUS, 1), 0.30f)
+				          .addProduct(OreDicPreferences.get("dustDraconium", 1), 0.15f)
+				          .setTemperature(EnumTemperature.COLD).setHumidity(EnumHumidity.ARID);
+			}
+		}
+
+		@Override
+		protected void setAlleles(IAllele[] template)
+		{
+			AlleleHelper.instance.set(template, EnumBeeChromosome.SPEED, EnumAllele.Speed.SLOW);
+		}
+
+		@Override
+		protected void registerMutations()
+		{
+
+			BeeManager.beeMutationFactory.createMutation(AustereBee, EnderBee, getTemplate(), MathUtil.maxInt((int)(5*Config.mutationMultipler),100)).restrictBiomeType(BiomeDictionary.Type.NETHER);
+
+		}
+	},
 
 	// Aquatic branch
 	PRISMARINE(BeeBranches.AQUATIC, "Prismarine", true, new Color(0x63ab9d), new Color(0xffdc16))
@@ -798,7 +955,11 @@ public enum BeeSpecies implements IBeeDefinition
 		@Override
 		protected void setSpeciesProperties(IAlleleBeeSpeciesBuilder beeSpecies)
 		{
-			beeSpecies.addProduct(PluginApiculture.items.beeComb.get(EnumHoneyComb.HONEY, 1), 0.30f).addProduct(new ItemStack(Items.PRISMARINE_CRYSTALS, 2), 0.2f).addProduct(new ItemStack(Items.PRISMARINE_SHARD, 2), 0.2f).setHasEffect().setTemperature(EnumTemperature.NORMAL).setHumidity(EnumHumidity.DAMP);
+			beeSpecies.addProduct(PluginApiculture.items.beeComb.get(EnumHoneyComb.HONEY, 1), 0.30f)
+			          .addProduct(new ItemStack(Items.PRISMARINE_CRYSTALS, 2), 0.2f)
+			          .addProduct(new ItemStack(Items.PRISMARINE_SHARD, 2), 0.2f)
+			          .setHasEffect()
+			          .setTemperature(EnumTemperature.NORMAL).setHumidity(EnumHumidity.DAMP);
 
 		}
 
@@ -825,7 +986,12 @@ public enum BeeSpecies implements IBeeDefinition
 		@Override
 		protected void setSpeciesProperties(IAlleleBeeSpeciesBuilder beeSpecies)
 		{
-			beeSpecies.addProduct(PluginApiculture.items.beeComb.get(EnumHoneyComb.SIMMERING, 1), 0.30f).addProduct(new ItemStack(Items.BLAZE_POWDER), 0.2f).addProduct(new ItemStack(Items.GUNPOWDER), 0.2f).addProduct(new ItemStack(Items.GHAST_TEAR), 0.05f).setTemperature(EnumTemperature.HELLISH).setHumidity(EnumHumidity.ARID);
+			beeSpecies.addProduct(PluginApiculture.items.beeComb.get(EnumHoneyComb.SIMMERING, 1), 0.30f)
+			          .addSpecialty(new ItemStack(Items.BLAZE_POWDER), 0.2f)
+			          .addSpecialty(new ItemStack(Items.GUNPOWDER), 0.2f)
+			          .addSpecialty(new ItemStack(Items.GHAST_TEAR), 0.05f)
+			          .setJubilanceProvider(BeeManager.jubilanceFactory.getRequiresResource(Blocks.LAVA.getDefaultState()))
+			          .setTemperature(EnumTemperature.HELLISH).setHumidity(EnumHumidity.ARID);
 		}
 
 		@Override
@@ -855,7 +1021,11 @@ public enum BeeSpecies implements IBeeDefinition
 		@Override
 		protected void setSpeciesProperties(IAlleleBeeSpeciesBuilder beeSpecies)
 		{
-			beeSpecies.addProduct(new ItemStack(MoreBeesItems.CombWither), 0.30f).addSpecialty(new ItemStack(Items.SKULL, 1, 1), 0.02f).setTemperature(EnumTemperature.HELLISH).setHumidity(EnumHumidity.ARID);
+			beeSpecies.addProduct(new ItemStack(MoreBeesItems.CombWither), 0.30f)
+			          .addSpecialty(new ItemStack(Items.SKULL, 1, 1), 0.02f)
+			          // needs custom provider to determine if the skull is a wither skull
+			          .setJubilanceProvider(BeeManager.jubilanceFactory.getRequiresResource(Blocks.SKULL.getDefaultState()))
+			          .setTemperature(EnumTemperature.HELLISH).setHumidity(EnumHumidity.ARID);
 
 		}
 
@@ -877,12 +1047,16 @@ public enum BeeSpecies implements IBeeDefinition
 
 		}
 	},
-	NETHERSTAR(BeeBranches.WITHER, "wither", false, new Color(0xc1c1c1), new Color(0x3c3c3c))
+	NETHERSTAR(BeeBranches.WITHER, "Wither", false, new Color(0xc1c1c1), new Color(0x3c3c3c))
 	{
 		@Override
 		protected void setSpeciesProperties(IAlleleBeeSpeciesBuilder beeSpecies)
 		{
-			beeSpecies.addProduct(new ItemStack(MoreBeesItems.CombWither), 0.35f).addSpecialty(new ItemStack(MoreBeesItems.NetherFrag), 0.05f).setHasEffect().setTemperature(EnumTemperature.HELLISH).setHumidity(EnumHumidity.ARID);
+			beeSpecies.addProduct(new ItemStack(MoreBeesItems.CombWither), 0.35f)
+			          .addSpecialty(new ItemStack(MoreBeesItems.NetherFrag), 0.05f)
+			          .setJubilanceProvider(BeeManager.jubilanceFactory.getRequiresResource(Blocks.SKULL.getDefaultState()))
+			          .setHasEffect()
+			          .setTemperature(EnumTemperature.HELLISH).setHumidity(EnumHumidity.ARID);
 		}
 
 		@Override
@@ -907,13 +1081,14 @@ public enum BeeSpecies implements IBeeDefinition
 		@Override
 		protected void setSpeciesProperties(IAlleleBeeSpeciesBuilder beeSpecies)
 		{
-			beeSpecies.addProduct(new ItemStack(MoreBeesItems.CombSlime), 0.70f).setTemperature(EnumTemperature.NORMAL).setHumidity(EnumHumidity.DAMP);
+			beeSpecies.addProduct(new ItemStack(MoreBeesItems.CombSlime), 0.70f)
+			          .setTemperature(EnumTemperature.NORMAL).setHumidity(EnumHumidity.DAMP);
 		}
 
 		@Override
 		protected void setAlleles(IAllele[] template)
 		{
-		
+
 			AlleleHelper.instance.set(template, EnumBeeChromosome.FLOWER_PROVIDER, Register.FlowerTypeSlime);
 			AlleleHelper.instance.set(template, EnumBeeChromosome.CAVE_DWELLING, false);
 			AlleleHelper.instance.set(template, EnumBeeChromosome.TERRITORY, EnumAllele.Territory.AVERAGE);
@@ -922,7 +1097,7 @@ public enum BeeSpecies implements IBeeDefinition
 			AlleleHelper.instance.set(template, EnumBeeChromosome.TEMPERATURE_TOLERANCE, EnumAllele.Tolerance.BOTH_1);
 			AlleleHelper.instance.set(template, EnumBeeChromosome.FERTILITY, EnumAllele.Fertility.NORMAL);
 			AlleleHelper.instance.set(template, EnumBeeChromosome.EFFECT, Register.effectSlimey);
-			
+
 		}
 
 		@Override
@@ -938,14 +1113,16 @@ public enum BeeSpecies implements IBeeDefinition
 		{
 			if(LoadMods.enableTinkers)
 			{
-				beeSpecies.addProduct(new ItemStack(MoreBeesItems.CombSlime), 0.55f).addProduct(OreDicPreferences.get("slimeballBlue", 1), 0.55f).setTemperature(EnumTemperature.NORMAL).setHumidity(EnumHumidity.DAMP);
+				beeSpecies.addProduct(new ItemStack(MoreBeesItems.CombSlime), 0.55f)
+				          .addProduct(OreDicPreferences.get("slimeballBlue", 1), 0.55f)
+				          .setTemperature(EnumTemperature.NORMAL).setHumidity(EnumHumidity.DAMP);
 			}
 		}
 
 		@Override
 		protected void setAlleles(IAllele[] template)
 		{
-		
+
 			AlleleHelper.instance.set(template, EnumBeeChromosome.SPEED, EnumAllele.Speed.NORMAL);
 		}
 
@@ -962,14 +1139,16 @@ public enum BeeSpecies implements IBeeDefinition
 		{
 			if(LoadMods.enableTinkers)
 			{
-				beeSpecies.addProduct(new ItemStack(MoreBeesItems.CombSlime), 0.55f).addProduct(OreDicPreferences.get("slimeballPurple", 1), 0.55f).setTemperature(EnumTemperature.NORMAL).setHumidity(EnumHumidity.DAMP);
+				beeSpecies.addProduct(new ItemStack(MoreBeesItems.CombSlime), 0.55f)
+				          .addProduct(OreDicPreferences.get("slimeballPurple", 1), 0.55f)
+				          .setTemperature(EnumTemperature.NORMAL).setHumidity(EnumHumidity.DAMP);
 			}
 		}
 
 		@Override
 		protected void setAlleles(IAllele[] template)
 		{
-		
+
 			AlleleHelper.instance.set(template, EnumBeeChromosome.SPEED, EnumAllele.Speed.NORMAL);
 		}
 
@@ -987,14 +1166,16 @@ public enum BeeSpecies implements IBeeDefinition
 		{
 			if(LoadMods.enableTinkers)
 			{
-				beeSpecies.addProduct(new ItemStack(MoreBeesItems.CombSlime), 0.55f).addProduct(OreDicPreferences.get("slimeballMagma", 1), 0.55f).setTemperature(EnumTemperature.HELLISH).setHumidity(EnumHumidity.ARID);
+				beeSpecies.addProduct(new ItemStack(MoreBeesItems.CombSlime), 0.55f)
+				          .addProduct(OreDicPreferences.get("slimeballMagma", 1), 0.55f)
+				          .setTemperature(EnumTemperature.HELLISH).setHumidity(EnumHumidity.ARID);
 			}
 		}
 
 		@Override
 		protected void setAlleles(IAllele[] template)
 		{
-			
+
 			AlleleHelper.instance.set(template, EnumBeeChromosome.SPEED, EnumAllele.Speed.NORMAL);
 		}
 
@@ -1011,9 +1192,9 @@ public enum BeeSpecies implements IBeeDefinition
 		protected void setSpeciesProperties(IAlleleBeeSpeciesBuilder beeSpecies)
 		{
 			beeSpecies.addProduct(PluginApiculture.items.beeComb.get(EnumHoneyComb.SILKY,1), 0.30f)
-			.addProduct(PluginApiculture.items.beeComb.get(EnumHoneyComb.STRINGY,1), 0.30f)
-			.addProduct(new ItemStack(Items.STRING,1), 0.70f)
-			.setTemperature(EnumTemperature.WARM).setHumidity(EnumHumidity.DAMP);
+			          .addProduct(PluginApiculture.items.beeComb.get(EnumHoneyComb.STRINGY,1), 0.30f)
+			          .addProduct(new ItemStack(Items.STRING,1), 0.70f)
+			          .setTemperature(EnumTemperature.WARM).setHumidity(EnumHumidity.DAMP);
 		}
 
 		@Override
@@ -1022,7 +1203,7 @@ public enum BeeSpecies implements IBeeDefinition
 			AlleleHelper.instance.set(template, EnumBeeChromosome.FERTILITY, EnumAllele.Fertility.NORMAL);
 			AlleleHelper.instance.set(template, EnumBeeChromosome.CAVE_DWELLING, false);
 			AlleleHelper.instance.set(template, EnumBeeChromosome.SPEED, EnumAllele.Speed.NORMAL);
-			
+
 		}
 
 		@Override
@@ -1031,7 +1212,7 @@ public enum BeeSpecies implements IBeeDefinition
 			BeeManager.beeMutationFactory.createMutation(TropicalBee, DiligentBee, getTemplate(), MathUtil.maxInt((int)(10*Config.mutationMultipler),100));
 		}
 	};
-	
+
 
 	// forestry bees
 	private static final IAlleleBeeSpecies[] hiveBees = {
@@ -1043,6 +1224,7 @@ public enum BeeSpecies implements IBeeDefinition
 			(IAlleleBeeSpecies) AlleleManager.alleleRegistry.getAllele("forestry.speciesWintry") };
 	private static IAlleleBeeSpecies SteadfastBee = (IAlleleBeeSpecies) AlleleManager.alleleRegistry.getAllele("forestry.speciesSteadfast");
 	private static IAlleleBeeSpecies CultivatedBee = (IAlleleBeeSpecies) AlleleManager.alleleRegistry.getAllele("forestry.speciesCultivated");
+	private static IAlleleBeeSpecies SinisterBee = (IAlleleBeeSpecies) AlleleManager.alleleRegistry.getAllele("forestry.speciesSinister");
 	private static IAlleleBeeSpecies FiendishBee = (IAlleleBeeSpecies) AlleleManager.alleleRegistry.getAllele("forestry.speciesFiendish");
 	private static IAlleleBeeSpecies IndustriousBee = (IAlleleBeeSpecies) AlleleManager.alleleRegistry.getAllele("forestry.speciesIndustrious");
 	private static IAlleleBeeSpecies ImperialBee = (IAlleleBeeSpecies) AlleleManager.alleleRegistry.getAllele("forestry.speciesImperial");
@@ -1052,12 +1234,13 @@ public enum BeeSpecies implements IBeeDefinition
 	private static IAlleleBeeSpecies BoggyBee = (IAlleleBeeSpecies) AlleleManager.alleleRegistry.getAllele("forestry.speciesBoggy");
 	private static IAlleleBeeSpecies DiligentBee = (IAlleleBeeSpecies) AlleleManager.alleleRegistry.getAllele("forestry.speciesDiligent");
 	private static IAlleleBeeSpecies TropicalBee = (IAlleleBeeSpecies) AlleleManager.alleleRegistry.getAllele("forestry.speciesTropical");
-	
+
 	// moreBees Bees
 	private static IAlleleBeeSpecies RockBee = (IAlleleBeeSpecies) AlleleManager.alleleRegistry.getAllele(MoreBees.MOD_ID+ ".speciesRock");
 	private static IAlleleBeeSpecies HardenedBee = (IAlleleBeeSpecies) AlleleManager.alleleRegistry.getAllele(MoreBees.MOD_ID+ ".speciesHardened");
 	private static IAlleleBeeSpecies ObsidianBee = (IAlleleBeeSpecies) AlleleManager.alleleRegistry.getAllele(MoreBees.MOD_ID+ ".speciesObsidian");
 	private static IAlleleBeeSpecies LapisBee = (IAlleleBeeSpecies) AlleleManager.alleleRegistry.getAllele(MoreBees.MOD_ID+ ".speciesLapis");
+	private static IAlleleBeeSpecies QuartzBee = (IAlleleBeeSpecies) AlleleManager.alleleRegistry.getAllele(MoreBees.MOD_ID+ ".speciesQuartz");
 	private static IAlleleBeeSpecies RedstoneBee = (IAlleleBeeSpecies) AlleleManager.alleleRegistry.getAllele(MoreBees.MOD_ID+ ".speciesRedstone");
 	private static IAlleleBeeSpecies EmeraldBee = (IAlleleBeeSpecies) AlleleManager.alleleRegistry.getAllele(MoreBees.MOD_ID+ ".speciesEmerald");
 	private static IAlleleBeeSpecies DirtBee = (IAlleleBeeSpecies) AlleleManager.alleleRegistry.getAllele(MoreBees.MOD_ID+ ".speciesDirt");
@@ -1074,7 +1257,9 @@ public enum BeeSpecies implements IBeeDefinition
 	private static IAlleleBeeSpecies BlueSlimeyBee = (IAlleleBeeSpecies) AlleleManager.alleleRegistry.getAllele(MoreBees.MOD_ID+ ".speciesBlueslimey");
 	private static IAlleleBeeSpecies PrismarineBee = (IAlleleBeeSpecies) AlleleManager.alleleRegistry.getAllele(MoreBees.MOD_ID+ ".speciesPrismarine");
 	private static IAlleleBeeSpecies CopperBee = (IAlleleBeeSpecies) AlleleManager.alleleRegistry.getAllele(MoreBees.MOD_ID+ ".speciesCopper");
-	
+	private static IAlleleBeeSpecies OsmiumBee = (IAlleleBeeSpecies) AlleleManager.alleleRegistry.getAllele(MoreBees.MOD_ID+ ".speciesOsmium");
+	private static IAlleleBeeSpecies DraconicBee = (IAlleleBeeSpecies) AlleleManager.alleleRegistry.getAllele(MoreBees.MOD_ID+ ".speciesDraconic");
+
 	private final IBranchDefinition branch;
 	private final IAlleleBeeSpecies species;
 
@@ -1161,14 +1346,14 @@ public enum BeeSpecies implements IBeeDefinition
 					}
 					break;
 				case RADIOACTIVE:
-					if(LoadMods.enableUranium && Config.radioactiveBees)
+					if((LoadMods.enableUranium || LoadMods.enableResonating) && Config.radioactiveBees)
 					{
 						bee.init();
 						bee.registerMutations();
 					}
 					break;
 				case URANIUM:
-					if(LoadMods.enableIC2 && Config.uranicBees)
+					if((LoadMods.enableIC2 || LoadMods.enableResonating) && Config.uranicBees)
 					{
 						bee.init();
 						bee.registerMutations();
@@ -1209,9 +1394,22 @@ public enum BeeSpecies implements IBeeDefinition
 						bee.registerMutations();
 					}
 					break;
-
 				case ARDITE:
 					if(LoadMods.enableTinkers && Config.tinkersMetalBees)
+					{
+						bee.init();
+						bee.registerMutations();
+					}
+					break;
+				case OSMIUM:
+					if(LoadMods.enableOsmium)
+					{
+						bee.init();
+						bee.registerMutations();
+					}
+					break;
+				case DRACONIC:
+					if(LoadMods.enableDraconium)
 					{
 						bee.init();
 						bee.registerMutations();

--- a/src/main/java/lach_01298/moreBees/MoreBees.java
+++ b/src/main/java/lach_01298/moreBees/MoreBees.java
@@ -16,11 +16,12 @@ import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPostInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 
-@Mod(modid = MoreBees.MOD_ID, name = "More Bees", version = MoreBees.VERSION, acceptedMinecraftVersions = MoreBees.MCVERSION , dependencies = "required-after:forestry;after:IndustrialCraft2;")
+@Mod(modid = MoreBees.MOD_ID, name = "More Bees", version = MoreBees.VERSION, acceptedMinecraftVersions = MoreBees.MCVERSION ,
+	dependencies = "required-after:forestry;after:IndustrialCraft2;after:Mekanism;after:draconicevolution")
 public class MoreBees
 {
 	public static final String MOD_ID = "morebees";
-	public static final String VERSION = "1.10.2-1.2";
+	public static final String VERSION = "1.10.2-1.2.1";
 	public static final String MCVERSION = "1.10.2";
 	@Mod.Instance(value = "morebees")
 	public static MoreBees instance;
@@ -39,6 +40,7 @@ public class MoreBees
 	@Mod.EventHandler
 	public void init(FMLInitializationEvent event)
 	{
+		LoadMods.loadLateMods();
 		RecipesCrafting.registerRecipes();
 		RecipesSmelting.registerRecipes();
 		RecipesCentrifuge.registerRecipes();

--- a/src/main/java/lach_01298/moreBees/Register.java
+++ b/src/main/java/lach_01298/moreBees/Register.java
@@ -48,8 +48,6 @@ import net.minecraftforge.oredict.OreDictionary;
 public class Register
 {
 	public static final String FlowerOre = "Ore";
-	public static final String FlowerDiamond = "Diamond";
-	public static final String FlowerEmerald = "Emerald";
 	public static final String FlowerRedstone = "Redstone";
 	public static final String FlowerUranium = "Uranium";
 	public static final String FlowerWater = "Water";
@@ -60,15 +58,13 @@ public class Register
 	public static IAlleleBeeEffect effectRadiation;
 	public static IAlleleBeeEffect effectSlimey;
 	public static IAlleleFlowers FlowerTypeOre;
-	public static IAlleleFlowers FlowerTypeDiamond;
-	public static IAlleleFlowers FlowerTypeEmerald;
 	public static IAlleleFlowers FlowerTypeRedstone;
 	public static IAlleleFlowers FlowerTypeUranium;
 	public static IAlleleFlowers FlowerTypeWater;
 	public static IAlleleFlowers FlowerTypeTNT;
 	public static IAlleleFlowers FlowerTypeSlime;
 	public static BlockHive beeHive;
-	
+
 	private static final String MOD_ID = MoreBees.MOD_ID;
 
 	public static void RegisterFlowers()
@@ -79,8 +75,6 @@ public class Register
 		flowerRegistry.registerAcceptableFlower(Blocks.IRON_ORE, FlowerOre);
 		flowerRegistry.registerAcceptableFlower(OreDicPreferences.getBlock("oreCopper"), FlowerOre);
 		flowerRegistry.registerAcceptableFlower(OreDicPreferences.getBlock("oreTin"), FlowerOre);
-		flowerRegistry.registerAcceptableFlower(Blocks.DIAMOND_ORE, FlowerDiamond);
-		flowerRegistry.registerAcceptableFlower(Blocks.EMERALD_ORE, FlowerEmerald);
 		flowerRegistry.registerAcceptableFlower(Blocks.REDSTONE_ORE, FlowerRedstone);
 		flowerRegistry.registerAcceptableFlower(Blocks.WATERLILY, FlowerWater);
 		flowerRegistry.registerAcceptableFlower(Blocks.TNT, FlowerTNT);
@@ -101,20 +95,26 @@ public class Register
 				flowerRegistry.registerAcceptableFlower(Block.getBlockFromItem(block.getItem()),FlowerUranium);
 			}
 		}
+		if(LoadMods.enableResonating)
+		{
+			List<ItemStack> list = OreDictionary.getOres("oreResonating");
+			for(ItemStack block : list)
+			{
+				flowerRegistry.registerAcceptableFlower(Block.getBlockFromItem(block.getItem()),FlowerUranium);
+			}
+		}
 		flowerRegistry.registerAcceptableFlower(Blocks.CHORUS_FLOWER, FlowerManager.FlowerTypeEnd);
 	}
 
 	public static void RegisterGenes()
 	{
 		FlowerTypeOre = AlleleManager.alleleFactory.createFlowers(MOD_ID, FlowerType, FlowerOre, Flowers.ORE.getValue(), true, EnumBeeChromosome.FLOWER_PROVIDER);
-		FlowerTypeDiamond = AlleleManager.alleleFactory.createFlowers(MOD_ID, FlowerType, FlowerDiamond, Flowers.DIAMOND.getValue(), true, EnumBeeChromosome.FLOWER_PROVIDER);
-		FlowerTypeEmerald = AlleleManager.alleleFactory.createFlowers(MOD_ID, FlowerType, FlowerEmerald, Flowers.EMERALD.getValue(), true, EnumBeeChromosome.FLOWER_PROVIDER);
 		FlowerTypeRedstone = AlleleManager.alleleFactory.createFlowers(MOD_ID, FlowerType, FlowerRedstone, Flowers.REDSTONE.getValue(), true, EnumBeeChromosome.FLOWER_PROVIDER);
 		FlowerTypeWater = AlleleManager.alleleFactory.createFlowers(MOD_ID, FlowerType, FlowerWater, Flowers.WATER.getValue(), true, EnumBeeChromosome.FLOWER_PROVIDER);
 		FlowerTypeTNT = AlleleManager.alleleFactory.createFlowers(MOD_ID, FlowerType, FlowerTNT, Flowers.TNT.getValue(), true, EnumBeeChromosome.FLOWER_PROVIDER);
 		FlowerTypeUranium = AlleleManager.alleleFactory.createFlowers(MOD_ID, FlowerType, FlowerUranium, Flowers.URANIUM.getValue(), true, EnumBeeChromosome.FLOWER_PROVIDER);
 		FlowerTypeSlime = AlleleManager.alleleFactory.createFlowers(MOD_ID, FlowerType, FlowerSlime, Flowers.SLIME.getValue(), true, EnumBeeChromosome.FLOWER_PROVIDER);
-		effectWither = new AlleleEffectPotion("wither", true, MobEffects.WITHER, 400);
+		effectWither = new AlleleEffectPotion("Wither", true, MobEffects.WITHER, 400);
 		AlleleManager.alleleRegistry.registerAllele(effectWither, EnumBeeChromosome.EFFECT );
 		effectRadiation = new AlleleEffectPotion("Radiation", true, MobEffects.HUNGER, 400);
 		AlleleManager.alleleRegistry.registerAllele(effectRadiation,  EnumBeeChromosome.EFFECT );
@@ -133,6 +133,6 @@ public class Register
 					new HiveDrop(0.8, BeeSpecies.ROCK, new ItemStack[] { rockComb }).setIgnobleShare(0.7),
 					new HiveDrop(0.03, BeeDefinition.VALIANT, new ItemStack[] { honeyComb }) });
 		}
-		
+
 	}
 }

--- a/src/main/java/lach_01298/moreBees/util/LoadMods.java
+++ b/src/main/java/lach_01298/moreBees/util/LoadMods.java
@@ -22,6 +22,9 @@ public class LoadMods
 	public static boolean enableSapphire = false;
 	public static boolean enableTinkers = false;
 	public static boolean enableIC2Classic = false;
+	public static boolean enableResonating = false;
+	public static boolean enableOsmium = false;
+	public static boolean enableDraconium = false;
 
 	public static void loadMods()
 	{
@@ -69,6 +72,16 @@ public class LoadMods
 		{
 			enableSapphire = true;
 		}
+		if(!OreDictionary.getOres((String) "oreResonating").isEmpty())
+		{
+			enableResonating = true;
+			Log.log((Level) Level.INFO, (String) "Loaded Deep Resonance fetures");
+		}
+		if(!OreDictionary.getOres((String) "dustDraconium").isEmpty())
+		{
+			enableDraconium = true;
+			Log.log((Level) Level.INFO, (String) "Loaded Draconic Evolution fetures");
+		}
 		if(Loader.isModLoaded((String) "IC2"))
 		{
 			try
@@ -109,5 +122,14 @@ public class LoadMods
 			}
 		}
 		Log.log((Level) Level.INFO, (String) "Loaded More Bees modCompat fetures");
+	}
+
+	public static void loadLateMods() {
+		if(!OreDictionary.getOres((String) "dustOsmium").isEmpty())
+		{
+			enableOsmium = true;
+			Log.log((Level) Level.INFO, (String) "Loaded Mekanism fetures");
+		}
+		Log.log((Level) Level.INFO, (String) "Loaded More Bees modCompat fetures for late registering mods");
 	}
 }

--- a/src/main/resources/assets/morebees/lang/en_US.lang
+++ b/src/main/resources/assets/morebees/lang/en_US.lang
@@ -22,6 +22,9 @@ for.bees.species.prismarine=Prismarine
 for.bees.species.apocalyptic=Apocalyptic
 for.bees.species.wither=Withering
 for.bees.species.netherstar=Wither
+for.bees.species.quartz=Quartz
+for.bees.species.osmium=Osmium
+for.bees.species.draconic=Draconic
 
 for.bees.species.aluminium=Aluminium
 for.bees.species.ruby=Ruby
@@ -111,6 +114,12 @@ morebees.description.speciesArdite=A very hard metal is produced by theses bees.
 morebees.description.speciesApatite=This bee takes nutriats out of the groud to create a fertiliser.
 
 morebees.description.speciesSulfur=You can smell these bees from a mile away becuase they produce smelly sulfur compounds.
+
+morebees.description.speciesQuartz=Not a diamond, but still shiny.
+
+morebees.description.speciesDraconic=These bees can conquer the end.
+
+morebees.description.speciesOsmium=These bees are very technical and industrious
 
 
 


### PR DESCRIPTION
This adds several new bees: a quartz bee in the crystal branch, an osmium bee for Mekanism osmium and draconium bee for Draconic Evolution.

Resonating ore from deep resonance now works in place of uranium if IC2 is not loaded.

Diamond and emerald bees use a specialty and a jubilance provider for being able to produce the nuggets. Using this method means it can't be changed using a mod like gendustry which can change flower types. Also, a jubilance provider was added to the withering and wither bees which already had their specialty items. (Todo: the jubilance provider for wither and withering bees needs to be customized; right now any skull/head placed under the hive will work, a custom provider can be written to limit only to wither skulls).