### PR TITLE
Missing conditional/jubilance change

### DIFF
--- a/src/main/java/lach_01298/moreBees/Genetics/BeeSpecies.java
+++ b/src/main/java/lach_01298/moreBees/Genetics/BeeSpecies.java
@@ -322,7 +322,7 @@ public enum BeeSpecies implements IBeeDefinition
 		{
 			beeSpecies.addProduct(new ItemStack(MoreBeesItems.CombRock), 0.30f)
 			          .addSpecialty(new ItemStack(MoreBeesItems.EmeraldFrag), 0.15f)
-			          .setJubilanceProvider(BeeManager.jubilanceFactory.getRequiresResource(Blocks.EMERALD_ORE.getDefaultState()))
+			          .setJubilanceProvider(BeeManager.jubilanceFactory.getRequiresResource(Blocks.EMERALD_BLOCK.getDefaultState()))
 			          .setTemperature(EnumTemperature.WARM).setHumidity(EnumHumidity.NORMAL);
 
 		}
@@ -353,7 +353,7 @@ public enum BeeSpecies implements IBeeDefinition
 		{
 			beeSpecies.addProduct(new ItemStack(MoreBeesItems.CombRock), 0.30f)
 			          .addSpecialty(new ItemStack(MoreBeesItems.DiamondFrag), 0.15f)
-			          .setJubilanceProvider(BeeManager.jubilanceFactory.getRequiresResource(Blocks.DIAMOND_ORE.getDefaultState()))
+			          .setJubilanceProvider(BeeManager.jubilanceFactory.getRequiresResource(Blocks.DIAMOND_BLOCK.getDefaultState()))
 			          .setHasEffect()
 			          .setTemperature(EnumTemperature.WARM).setHumidity(EnumHumidity.NORMAL);
 
@@ -1387,6 +1387,7 @@ public enum BeeSpecies implements IBeeDefinition
 					}
 					break;
 				case URANIUM:
+					if(LoadMods.enableIC2 && Config.uranicBees)
 					{
 						bee.init();
 						bee.registerMutations();


### PR DESCRIPTION
After merging in the changes I noticed you missed the conditional on the uranic bee registration.

Also, I would still have the jubilance provider for diamond and emerald be blocks, not ore. This way an ore somewhere in the area is needed to get the bee to start ticking as its flower, but each hive that has one of these bees needs to have a block under it to get the special product to produce. For me the concern was getting emerald ore. Unless an installed mod changes emerald ore spawning, finding it was a pain; diamond ore was easy enough, but not emerald. Base Minecraft really wants you to get emeralds from villagers, which is fairly easy once you find a village in your world.