### PR TITLE
Undo change to match forestry code base

### DIFF
--- a/src/main/java/lach_01298/moreBees/Genetics/WitherSkullJubilance.java
+++ b/src/main/java/lach_01298/moreBees/Genetics/WitherSkullJubilance.java
@@ -18,7 +18,7 @@ public class WitherSkullJubilance implements IJubilanceProvider {
 
 		TileEntity tile;
 		do {
-			pos = pos.up();
+			pos = pos.down();
 			tile = world.getTileEntity(pos);
 		} while (tile instanceof IBeeHousing && pos.getY() > 0);
 


### PR DESCRIPTION
The original code was correct. Block jubilance providers go under a hive. That particular code loop was lifted straight from Forestry's block jubilance provider; it is used to find the first block position under a hive (or possible stack of hives). The reason a custom provider is needed here, is a skull is a tileentity, not just a block.