### PR TITLE
Adjust carpenter crafting times and recipes

### DIFF
--- a/src/main/java/lach_01298/moreBees/recipes/RecipesCarpenter.java
+++ b/src/main/java/lach_01298/moreBees/recipes/RecipesCarpenter.java
@@ -12,6 +12,7 @@ import forestry.core.utils.OreDictUtil;
 import lach_01298.moreBees.item.MoreBeesItems;
 import lach_01298.moreBees.util.OreDicPreferences;
 import lach_01298.moreBees.util.LoadMods;
+import lach_01298.moreBees.util.Config;
 
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
@@ -43,83 +44,91 @@ public class RecipesCarpenter
 				'S', Blocks.SOUL_SAND,
 				'R',PluginApiculture.items.royalJelly);
 
-		RecipeManagers.carpenterManager.addRecipe(50, new FluidStack(FluidRegistry.WATER, 500), null, new ItemStack(Items.QUARTZ),
+		RecipeManagers.carpenterManager.addRecipe(20, new FluidStack(FluidRegistry.WATER, 500), null, new ItemStack(Items.QUARTZ),
 				" G ", "G G", " G ",
 				'G',MBI.GrainsCrystal);
-		RecipeManagers.carpenterManager.addRecipe(50, new FluidStack(FluidRegistry.WATER, 500), null, new ItemStack(Items.REDSTONE),
+		RecipeManagers.carpenterManager.addRecipe(20, new FluidStack(FluidRegistry.WATER, 500), null, new ItemStack(Items.REDSTONE),
 				"G G", "   ", "G G",
 				'G',MBI.GrainsCrystal);
-		RecipeManagers.carpenterManager.addRecipe(200, new FluidStack(FluidRegistry.WATER, 1000), null, new ItemStack(MBI.EmeraldFrag),
+		RecipeManagers.carpenterManager.addRecipe(60, new FluidStack(FluidRegistry.WATER, 1000), null, new ItemStack(MBI.EmeraldFrag),
 				"G G", "GGG", "G G",
 				'G',MBI.GrainsCrystal);
-		RecipeManagers.carpenterManager.addRecipe(200, new FluidStack(FluidRegistry.WATER, 1000), null, new ItemStack(MBI.DiamondFrag),
+		RecipeManagers.carpenterManager.addRecipe(60, new FluidStack(FluidRegistry.WATER, 1000), null, new ItemStack(MBI.DiamondFrag),
 				"GGG", "G G", "GGG",
 				'G',MBI.GrainsCrystal);
-		RecipeManagers.carpenterManager.addRecipe(75, new FluidStack(FluidRegistry.WATER, 1000), null, new ItemStack(PluginCore.items.apatite),
+		RecipeManagers.carpenterManager.addRecipe(40, new FluidStack(FluidRegistry.WATER, 1000), null, new ItemStack(PluginCore.items.apatite),
 				"G G", " G ", "G G",
 				'G',MBI.GrainsCrystal);
 		if (LoadMods.enableRuby)
 		{
-			RecipeManagers.carpenterManager.addRecipe(150, new FluidStack(FluidRegistry.WATER, 1000), null, OreDicPreferences.get("gemRuby", 1),
+			RecipeManagers.carpenterManager.addRecipe(75, new FluidStack(FluidRegistry.WATER, 1000), null, OreDicPreferences.get("gemRuby", 1),
 					"G G", "GGG", "GGG",
 					'G',MBI.GrainsCrystal);
 	    }
 		if (LoadMods.enableSapphire)
 		{
-			RecipeManagers.carpenterManager.addRecipe(150, new FluidStack(FluidRegistry.WATER, 1000), null, OreDicPreferences.get("gemSapphire", 1),
+			RecipeManagers.carpenterManager.addRecipe(75, new FluidStack(FluidRegistry.WATER, 1000), null, OreDicPreferences.get("gemSapphire", 1),
 					"GGG", "GGG", "G G",
 					'G',MBI.GrainsCrystal);
 	    }
 
-		RecipeManagers.carpenterManager.addRecipe(50, new FluidStack(FluidRegistry.WATER, 500), null, OreDicPreferences.get("dustIron", 1),
+		RecipeManagers.carpenterManager.addRecipe(25, new FluidStack(FluidRegistry.WATER, 500), null, OreDicPreferences.get("dustIron", 1),
 				" G ", "G G", "   ",
 				'G',MBI.GrainsMetallic);
-		RecipeManagers.carpenterManager.addRecipe(50, new FluidStack(FluidRegistry.WATER, 500), null, OreDicPreferences.get("dustCopper", 1),
+		RecipeManagers.carpenterManager.addRecipe(25, new FluidStack(FluidRegistry.WATER, 500), null, OreDicPreferences.get("dustCopper", 1),
 				"   ", "G G", " G ",
 				'G',MBI.GrainsMetallic);
-		RecipeManagers.carpenterManager.addRecipe(75, new FluidStack(FluidRegistry.WATER, 500), null, OreDicPreferences.get("dustTin", 1),
+		RecipeManagers.carpenterManager.addRecipe(30, new FluidStack(FluidRegistry.WATER, 500), null, OreDicPreferences.get("dustTin", 1),
 				" G ", "G G", " G ",
 				'G',MBI.GrainsMetallic);
-		RecipeManagers.carpenterManager.addRecipe(125, new FluidStack(FluidRegistry.WATER, 1000), null, OreDicPreferences.get("dustGold", 1),
+		RecipeManagers.carpenterManager.addRecipe(40, new FluidStack(FluidRegistry.WATER, 1000), null, OreDicPreferences.get("dustGold", 1),
 				"G G", "GGG", "G G",
 				'G',MBI.GrainsMetallic);
 		if (LoadMods.enableSilver)
 		{
-			RecipeManagers.carpenterManager.addRecipe(100, new FluidStack(FluidRegistry.WATER, 1000), null, OreDicPreferences.get("dustSilver", 1),
+			RecipeManagers.carpenterManager.addRecipe(35, new FluidStack(FluidRegistry.WATER, 1000), null, OreDicPreferences.get("dustSilver", 1),
 					"G G", " G ", "G G",
 					'G',MBI.GrainsMetallic);
 		}
 		if (LoadMods.enableLead)
 		{
-			RecipeManagers.carpenterManager.addRecipe(100, new FluidStack(FluidRegistry.WATER, 750), null, OreDicPreferences.get("dustLead", 1),
+			RecipeManagers.carpenterManager.addRecipe(30, new FluidStack(FluidRegistry.WATER, 750), null, OreDicPreferences.get("dustLead", 1),
 					" G ", "GGG", " G ",
 					'G',MBI.GrainsMetallic);
 	    }
 		if (LoadMods.enableAluminium)
 		{
-			RecipeManagers.carpenterManager.addRecipe(100, new FluidStack(FluidRegistry.WATER, 750), null, OreDicPreferences.get("dustAluminium", 1),
+			RecipeManagers.carpenterManager.addRecipe(30, new FluidStack(FluidRegistry.WATER, 750), null, OreDicPreferences.get("dustAluminium", 1),
 					"G G", "   ", "G G",
 					'G',MBI.GrainsMetallic);
 	    }
 		if (LoadMods.enableOsmium)
 		{
-			RecipeManagers.carpenterManager.addRecipe(100, new FluidStack(FluidRegistry.WATER, 750), null, OreDicPreferences.get("dustOsmium", 1),
+			RecipeManagers.carpenterManager.addRecipe(30, new FluidStack(FluidRegistry.WATER, 750), null, OreDicPreferences.get("dustOsmium", 1),
 					"GGG", "   ", "G G",
 					'G',MBI.GrainsMetallic);
 		}
 		if(LoadMods.enableTinkers)
 		{
-			RecipeManagers.carpenterManager.addRecipe(100, new FluidStack(FluidRegistry.WATER, 1500), null, OreDicPreferences.get("nuggetCobalt", 1),
+			RecipeManagers.carpenterManager.addRecipe(25, new FluidStack(FluidRegistry.WATER, 1500), null, OreDicPreferences.get("nuggetCobalt", 1),
 					"GGG", "GGG", "G G",
 					'G',MBI.GrainsMetallic);
-			RecipeManagers.carpenterManager.addRecipe(100, new FluidStack(FluidRegistry.WATER, 1500), null, OreDicPreferences.get("nuggetArdite", 1),
+			RecipeManagers.carpenterManager.addRecipe(25, new FluidStack(FluidRegistry.WATER, 1500), null, OreDicPreferences.get("nuggetArdite", 1),
 					"G G", "GGG", "GGG",
 					'G',MBI.GrainsMetallic);
 		}
 
-		RecipeManagers.carpenterManager.addRecipe(1000, new FluidStack(FluidRegistry.LAVA, 4000), null, new ItemStack(Items.NETHER_STAR),
-				"FF", "FF",
-				'F',MBI.NetherFrag);
+		if (Config.useCarpenterCrafting) {
+			RecipeManagers.carpenterManager.addRecipe(600, new FluidStack(FluidRegistry.LAVA, 4000), null, new ItemStack(Items.NETHER_STAR),
+					"FF", "FF",
+					'F',MBI.NetherFrag);
+			RecipeManagers.carpenterManager.addRecipe(100, new FluidStack(FluidRegistry.LAVA, 1000), null, new ItemStack(Items.DIAMOND),
+					"FFF", "FFF", "FFF",
+					'F',MBI.DiamondFrag);
+			RecipeManagers.carpenterManager.addRecipe(100, new FluidStack(FluidRegistry.LAVA, 1000), null, new ItemStack(Items.EMERALD),
+					"FFF", "FFF", "FFF",
+					'F',MBI.EmeraldFrag);
+		}
 
 	}
 }

--- a/src/main/java/lach_01298/moreBees/recipes/RecipesCrafting.java
+++ b/src/main/java/lach_01298/moreBees/recipes/RecipesCrafting.java
@@ -1,6 +1,7 @@
 package lach_01298.moreBees.recipes;
 
 import lach_01298.moreBees.item.MoreBeesItems;
+import lach_01298.moreBees.util.Config;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fml.common.registry.GameRegistry;
@@ -13,9 +14,12 @@ public class RecipesCrafting
 
 	public static void registerRecipes()
 	{
-		GameRegistry.addShapelessRecipe(new ItemStack(Items.DIAMOND), MBI.DiamondFrag,MBI.DiamondFrag,MBI.DiamondFrag,MBI.DiamondFrag,MBI.DiamondFrag,MBI.DiamondFrag,MBI.DiamondFrag,MBI.DiamondFrag,MBI.DiamondFrag);
-		GameRegistry.addShapelessRecipe(new ItemStack(Items.EMERALD), MBI.EmeraldFrag,MBI.EmeraldFrag,MBI.EmeraldFrag,MBI.EmeraldFrag,MBI.EmeraldFrag,MBI.EmeraldFrag,MBI.EmeraldFrag,MBI.EmeraldFrag,MBI.EmeraldFrag);
-		//GameRegistry.addShapelessRecipe(new ItemStack(Items.NETHER_STAR),MBI.NetherFrag,MBI.NetherFrag,MBI.NetherFrag,MBI.NetherFrag);
+		if (!Config.useCarpenterCrafting)
+		{
+			GameRegistry.addShapelessRecipe(new ItemStack(Items.DIAMOND), MBI.DiamondFrag,MBI.DiamondFrag,MBI.DiamondFrag,MBI.DiamondFrag,MBI.DiamondFrag,MBI.DiamondFrag,MBI.DiamondFrag,MBI.DiamondFrag,MBI.DiamondFrag);
+			GameRegistry.addShapelessRecipe(new ItemStack(Items.EMERALD), MBI.EmeraldFrag,MBI.EmeraldFrag,MBI.EmeraldFrag,MBI.EmeraldFrag,MBI.EmeraldFrag,MBI.EmeraldFrag,MBI.EmeraldFrag,MBI.EmeraldFrag,MBI.EmeraldFrag);
+			GameRegistry.addShapelessRecipe(new ItemStack(Items.NETHER_STAR),MBI.NetherFrag,MBI.NetherFrag,MBI.NetherFrag,MBI.NetherFrag);
+		}
 	}
 
 

--- a/src/main/java/lach_01298/moreBees/util/Config.java
+++ b/src/main/java/lach_01298/moreBees/util/Config.java
@@ -36,6 +36,8 @@ public class Config
 
 	public static float mutationMultipler = 1.0f;
 
+	public static boolean useCarpenterCrafting = true;
+
 	public static void readConfig()
 	{
 		Configuration cfg = CommonProxy.config;
@@ -63,7 +65,7 @@ public class Config
 	{
 		cfg.addCustomCategoryComment(CATEGORY_GENERAL, "General configuration");
 		enableFrames = cfg.getBoolean("enableFrames", CATEGORY_GENERAL, enableFrames, "Set to false to disable More Bees frames e.g. mutating frame.");
-
+		useCarpenterCrafting = cfg.getBoolean("useCarpenterCrafting", CATEGORY_GENERAL, useCarpenterCrafting, "Set to false to craft fragments (diamonds, emeralds, nether stars) in a crafting table.");
 	}
 
 	private static void initWordGenConfig(Configuration cfg)


### PR DESCRIPTION
I've been using this on my survival world and found the new carpenter crafting times to be excessive, so I trimmed them back. I also added a config option as to whether or not to use the carpenter for crafting the fragments. I really like not being able to mass craft diamonds, etc, but having to wait while the carpenter works. 

I am finding the nether star fragments are dropping a little to often and you might want to lower the drop rate for them on the wither bees.