### PR TITLE
Make IC2-classic-spmod recipe for rocky comb the default 

### DIFF
--- a/src/main/java/com/tencao/morebees/recipes/RecipesCentrifuge.kt
+++ b/src/main/java/com/tencao/morebees/recipes/RecipesCentrifuge.kt
@@ -25,8 +25,7 @@ object RecipesCentrifuge {
                     ItemStack(Blocks.STONE, 1, 3), 0.5f,
                     ItemStack(Blocks.STONE, 1, 5), 0.5f,
                     OreDictUtil.getOreStack("dustStone"), 0.9f))
-        }
-        if (Loader.isModLoaded("IC2-Classic-Spmod")){
+        } else {
             RecipeManagers.centrifugeManager.addRecipe(20, ItemStack(MBItems.CombRock), ImmutableMap.of(
                     ModuleCore.getItems().beeswax.itemStack, 1.0f,
                     ItemStack(Blocks.COBBLESTONE), 0.9f,


### PR DESCRIPTION
Make IC2-classic-spmod recipe for rocky comb the default  for all installs of this mod. Only load dustStone recipe for IC2.

Upon reviewing the recipes, this was the most logical (and I believe originally intended) choice for this. The default recipe produces stone and cobblestone, the IC2 recipe produces Stone Dust, an item only available with the new IC2.

This PR addresses #85 and allows this mod to work without IC2 again.